### PR TITLE
appender: refactor limit-by-size logic to remove the log index tracking

### DIFF
--- a/tracing-appender/src/rolling/builder.rs
+++ b/tracing-appender/src/rolling/builder.rs
@@ -264,15 +264,6 @@ impl Builder {
     pub fn build(&self, directory: impl AsRef<Path>) -> Result<RollingFileAppender, InitError> {
         RollingFileAppender::from_builder(self, directory)
     }
-
-    #[cfg(test)]
-    pub(super) fn build_with_now(
-        &self,
-        directory: impl AsRef<Path>,
-        now: Box<dyn Fn() -> time::OffsetDateTime + Send + Sync>,
-    ) -> Result<RollingFileAppender, InitError> {
-        RollingFileAppender::from_builder_with_custom_now(self, directory, now)
-    }
 }
 
 impl Default for Builder {


### PR DESCRIPTION
Refactor the limit-by-size logic as described in this [comment](https://github.com/tokio-rs/tracing/pull/2497#issuecomment-2212476867).

This [function](https://github.com/CBenoit/tracing/pull/1/files#diff-5042ae34347788466f8ab0443a19d2a64de1f4f8143bf7e42a43af4ba0a0d211R714) summarizes the new logic

Additionally, I've tried to remove unnecessary code to focus the PR on the new filter logic and make the reviewer's job easier.